### PR TITLE
New API endpoints for 694

### DIFF
--- a/bctw-api/src/apis/map_api.ts
+++ b/bctw-api/src/apis/map_api.ts
@@ -9,6 +9,24 @@ import { HistoricalTelemetryInput } from '../types/point';
 /**
  * Request all collars the user has access to.
  */
+ const getCrittersEstimate = function (req: Request, res: Response): void {
+  const {start, end} = req.query;
+  const fn_name = 'is_pings_cap';
+  const sql = `select is_pings_cap from ${S_BCTW}.${fn_name}('${getUserIdentifier(req)}', '${start}', '${end}')`;
+
+  const done = function (err, data) {
+    if (err) {
+      return res.status(500).send(`Failed to query database: ${err}`);
+    }
+    const is_cap = data.rows[0];
+    res.send(is_cap);
+  };
+  pgPool.query(sql, done);
+};
+
+/**
+ * Request all collars the user has access to.
+ */
 const getDBCritters = function (req: Request, res: Response): void {
   const {start, end} = req.query;
   const fn_name = 'get_telemetry';
@@ -124,4 +142,5 @@ export {
   getCritterTracks,
   getDBCritters,
   upsertPointTelemetry,
+  getCrittersEstimate
 }

--- a/bctw-api/src/apis/map_api.ts
+++ b/bctw-api/src/apis/map_api.ts
@@ -7,9 +7,10 @@ import { IBulkResponse } from '../types/import_types';
 import { HistoricalTelemetryInput } from '../types/point';
 
 /**
- * Request all collars the user has access to.
+ * Request that the backend make an estimate on the amount of telemetry data points a user may request
+ * based on the amount of critters assigned to this user under the time range.
  */
- const getCrittersEstimate = function (req: Request, res: Response): void {
+ const getPingsEstimate = function (req: Request, res: Response): void {
   const {start, end} = req.query;
   const fn_name = 'is_pings_cap';
   const sql = `select is_pings_cap from ${S_BCTW}.${fn_name}('${getUserIdentifier(req)}', '${start}', '${end}')`;
@@ -142,5 +143,5 @@ export {
   getCritterTracks,
   getDBCritters,
   upsertPointTelemetry,
-  getCrittersEstimate
+  getPingsEstimate
 }

--- a/bctw-api/src/server.ts
+++ b/bctw-api/src/server.ts
@@ -51,6 +51,7 @@ const app = express()
   // map
   .get('/get-critters', api.getDBCritters)
   .get('/get-critter-tracks', api.getCritterTracks)
+  .get('/get-critters-estimate', api.getCrittersEstimate)
   // animals
   .get('/get-animals', api.getAnimals)
   .get('/get-animal-history/:animal_id', api.getAnimalHistory)

--- a/bctw-api/src/server.ts
+++ b/bctw-api/src/server.ts
@@ -51,7 +51,7 @@ const app = express()
   // map
   .get('/get-critters', api.getDBCritters)
   .get('/get-critter-tracks', api.getCritterTracks)
-  .get('/get-critters-estimate', api.getPingsEstimate)
+  .get('/get-pings-estimate', api.getPingsEstimate)
   // animals
   .get('/get-animals', api.getAnimals)
   .get('/get-animal-history/:animal_id', api.getAnimalHistory)

--- a/bctw-api/src/server.ts
+++ b/bctw-api/src/server.ts
@@ -51,7 +51,7 @@ const app = express()
   // map
   .get('/get-critters', api.getDBCritters)
   .get('/get-critter-tracks', api.getCritterTracks)
-  .get('/get-critters-estimate', api.getCrittersEstimate)
+  .get('/get-critters-estimate', api.getPingsEstimate)
   // animals
   .get('/get-animals', api.getAnimals)
   .get('/get-animal-history/:animal_id', api.getAnimalHistory)

--- a/bctw-api/src/start.ts
+++ b/bctw-api/src/start.ts
@@ -13,7 +13,7 @@ import {
   getCollarsAndDeviceIds,
   upsertCollar,
 } from './apis/collar_api';
-import { getCritterTracks, getDBCritters, getCrittersEstimate } from './apis/map_api';
+import { getCritterTracks, getDBCritters, getPingsEstimate } from './apis/map_api';
 import { approveOrDenyPermissionRequest, getGrantedPermissionHistory, getPermissionRequests, submitPermissionRequest } from './apis/permission_api';
 import {
   upsertUser,
@@ -122,7 +122,7 @@ export {
   getCollarChangeHistory,
   getCritterTracks,
   getDBCritters,
-  getCrittersEstimate,
+  getPingsEstimate,
   getExportData,
   getGrantedPermissionHistory,
   getPermissionRequests,

--- a/bctw-api/src/start.ts
+++ b/bctw-api/src/start.ts
@@ -13,7 +13,7 @@ import {
   getCollarsAndDeviceIds,
   upsertCollar,
 } from './apis/collar_api';
-import { getCritterTracks, getDBCritters } from './apis/map_api';
+import { getCritterTracks, getDBCritters, getCrittersEstimate } from './apis/map_api';
 import { approveOrDenyPermissionRequest, getGrantedPermissionHistory, getPermissionRequests, submitPermissionRequest } from './apis/permission_api';
 import {
   upsertUser,
@@ -122,6 +122,7 @@ export {
   getCollarChangeHistory,
   getCritterTracks,
   getDBCritters,
+  getCrittersEstimate,
   getExportData,
   getGrantedPermissionHistory,
   getPermissionRequests,


### PR DESCRIPTION
This adds a new API endpoint at get-critters-estimate, for use on the map page in estimating volume of data returned by making critter search requests 