### PR TITLE
835-last-telemetry-export

### DIFF
--- a/bctw-api/src/export/export.ts
+++ b/bctw-api/src/export/export.ts
@@ -107,8 +107,9 @@ const getAllExportData = async function (
   const end = req.body.range.end;
   const polygons =
     'ARRAY[ ' + req.body.polygons.map((o) => `'${o}'`).join(', ') + ']::text[]';
-  const sql = `SELECT * FROM bctw.export_telemetry_with_params('${idir}', '${queries}', '${start}', '${end}', ${polygons}); `;
-
+  const lastTelemetryOnly = req.body.lastTelemetryOnly;
+  const attachedOnly = req.body.attachedOnly;
+  const sql = `SELECT * FROM bctw.export_telemetry_with_params('${idir}', '${queries}', '${start}', '${end}', ${polygons}, ${lastTelemetryOnly}, ${attachedOnly}); `;
   const { result, error, isError } = await query(
     sql,
     'failed to retrieve telemetry'


### PR DESCRIPTION
This PR adds support to the export-all endpoint to allow filtering export data by most recent telemetry points only and/or attached animals only.