### PR TITLE
887 export dropdown fix

### DIFF
--- a/bctw-api/src/server.ts
+++ b/bctw-api/src/server.ts
@@ -63,6 +63,7 @@ export const app = express()
   .get('/get-pings-estimate', api.getPingsEstimate)
   // animals
   .get('/get-animals', api.getAnimals)
+  .get('/get-attached-historic', api.getAttachedHistoric)
   .get('/get-animal-history/:animal_id', api.getAnimalHistory)
   .post('/upsert-animal', api.upsertAnimal)
   // devices

--- a/bctw-api/src/start.ts
+++ b/bctw-api/src/start.ts
@@ -11,6 +11,7 @@ import {
   getAnimalHistory,
   getAnimals,
   upsertAnimal,
+  getAttachedHistoric
 } from './apis/animal_api';
 import {
   addCode,
@@ -166,6 +167,7 @@ export {
   getCollarChangeHistory,
   getCritterTracks,
   getDBCritters,
+  getAttachedHistoric,
   getPingsEstimate,
   getExportData,
   getAllExportData,


### PR DESCRIPTION
Added a new endpoint that will give you collar-animal detail that includes no longer attached records. Using the assigned animals endpoint for the export page was problematic since you wouldn't be able to select device IDs, WLH IDs etc that you should have permission to export data for if they had been taken off an animal.

This also has a bit of a work around to solve potential heap overflow crashes when requesting data by WLH ID or Animal ID. Previously doing this would basically just fetch all data over the requested timespan (so basically the whole data set if you click All Telemetry) and then filter it by wlh_id/animal_id in the API, and this can crash it. Instead, we pass the critter_ids obtained from critterbase as another filter condition to the BCTW query. This works pretty well for now but will need to approach this with greater effort later to improve the stability of really big data requests.