### PR TITLE
927 add support for critterbase validation to import template

### DIFF
--- a/bctw-api/src/import/csv.ts
+++ b/bctw-api/src/import/csv.ts
@@ -11,6 +11,7 @@ import {
   determineExistingAnimal,
   getCodeHeaderName,
   getCritterbaseMarkingsFromRow,
+  getValuesForCodeHeader,
   isOnSameDay,
   mapXlsxHeader,
   projectUTMToLatLon,
@@ -82,6 +83,7 @@ const deviceMetadataSheetName = 'Device Metadata';
 const telemetrySheetName = 'Telemetry';
 const validSheetNames = [deviceMetadataSheetName]; //, telemetrySheetName];
 const extraCodeFields = ['species'];
+const critterBaseCodeFields = {ear_tag_left_colour: 'lookups/colours', ear_tag_right_colour: 'lookups/colours'};
 
 const obtainColumnTypes = async (): Promise<ColumnTypeMapping> => {
   const sql =
@@ -181,6 +183,7 @@ const parseXlsx = async (
         const errors = await validateGenericRow(
           crow,
           code_header_names,
+          critterBaseCodeFields,
           columnTypes,
           user
         );
@@ -598,25 +601,11 @@ const getTemplateFile = async function (
   for (let header_idx = 1; header_idx < headerRow.cellCount; header_idx++) {
     const cell = headerRow.getCell(header_idx);
     const code_header = getCodeHeaderName(cell.text);
-    if (code_header_names.includes(code_header)) {
-      const sql = constructFunctionQuery(
-        'get_code',
-        [idir, code_header, 0],
-        false,
-        S_API
-      );
-      const { result, isError } = await query(sql, 'failed to retrieve codes');
 
-      if (isError) {
-        res
-          .status(500)
-          .send('Unable to determine codes from the provided header');
-        return;
-      }
+    const code_descriptions: string[] = await getValuesForCodeHeader(code_header, idir, code_header_names, critterBaseCodeFields);
 
-      const code_descriptions = getRowResults(result, 'get_code').map(
-        (o) => o.description
-      );
+    if (code_descriptions.length) {
+      
       const col = cell.address.replace(/[0-9]/g, '');
 
       const val_col = computeXLSXCol(val_header_idx);


### PR DESCRIPTION
This adds support for validating certain columns against lookup tables in critterbase to the excel import page template. Unless we can find a better way to determine this, the fields and their relevant endpoints need to be hardcoded. In this commit, I have it set up to map ear_tag_left_colour and ear_tag_right_colour to lk_colour in Critterbase. 