### PR TITLE
268 duplicate user animal inserts

### DIFF
--- a/bctw-api/src/apis/animal_api.ts
+++ b/bctw-api/src/apis/animal_api.ts
@@ -118,7 +118,7 @@ const _getUnattachedSQL = (
     WITH ${alias} AS (
       SELECT caa.critter_id, ${fn_get_user_animal_permission}('${username}', caa.critter_id) AS "permission_type"
       FROM ${S_API}.collar_animal_assignment_v caa
-      WHERE NOT is_valid(now(), caa.valid_from, caa.valid_to) 
+      WHERE NOT is_valid(now(), caa.attachment_start, caa.attachment_end) 
       AND NOT (caa.critter_id IN ( 
         SELECT currently_attached_collars_v.critter_id
         FROM bctw_dapi_v1.currently_attached_collars_v))

--- a/bctw-api/src/apis/collar_api.ts
+++ b/bctw-api/src/apis/collar_api.ts
@@ -166,6 +166,8 @@ const getAttachedDeviceSQL = function (
   WHERE permission_type IS NOT NULL
   ${collar_id ? ` AND ${alias}.collar_id = '${collar_id}'` : ''}`;
 
+  console.log(base);
+
   const sql = constructGetQuery({
     base,
     order: [

--- a/bctw-api/src/auth/authorization.ts
+++ b/bctw-api/src/auth/authorization.ts
@@ -37,6 +37,7 @@ export const authorizeRequest = async (
   // A Route with no defined allowed audiences can only accept registered BCTW users
   const allowedAudiences = ROUTE_AUDIENCES[req.path];
   if (!allowedAudiences || allowedAudiences.length === 0) {
+    console.log(' A Route with no defined allowed audiences can only accept registered BCTW users')
     res.status(403).send('Forbidden');
     return;
   }
@@ -51,6 +52,7 @@ export const authorizeRequest = async (
     !allowedAudiences.includes(origin) ||
     (!user.registered && (origin === 'BCTW' || origin === 'SIMS'))
   ) {
+    console.log("If the user's origin isn't included, or the user is from BCTW or SIMS and isn't registered, return a forbidden error")
     res.status(403).send('Forbidden');
     return;
   }

--- a/bctw-api/src/import/csv.ts
+++ b/bctw-api/src/import/csv.ts
@@ -532,7 +532,7 @@ const upsertBulkv2 = async (id: string, req: Request) => {
         VALUES (bctw.get_user_id('${user_id}'), '${link_critter_id}', bctw.get_user_id('${id}'), 'manager')`);
 
       const link_res = await client.query(
-        `SELECT bctw.link_collar_to_animal('${id}', '${link_collar_id}', '${link_critter_id}', '${data_start}', '${data_start}', ${formattedEnd}, ${formattedEnd})`
+        `SELECT bctw.link_collar_to_animal('${id}', '${link_collar_id}', '${link_critter_id}', '${data_start}', '${data_start}', ${formattedEnd})`
       );
       const link_row = getRowResults(link_res, 'link_collar_to_animal')[0];
       

--- a/bctw-api/src/import/csv.ts
+++ b/bctw-api/src/import/csv.ts
@@ -529,7 +529,11 @@ const upsertBulkv2 = async (id: string, req: Request) => {
 
       await client.query(`INSERT INTO bctw.user_animal_assignment 
         (user_id, critter_id, created_by_user_id, permission_type)
-        VALUES (bctw.get_user_id('${user_id}'), '${link_critter_id}', bctw.get_user_id('${id}'), 'manager')`);
+        SELECT bctw.get_user_id('${user_id}'), '${link_critter_id}', bctw.get_user_id('${id}'), 'manager'
+        WHERE NOT EXISTS 
+          (SELECT 1 FROM bctw.user_animal_assignment 
+            WHERE user_id = bctw.get_user_id('${id}') 
+            AND critter_id = '${link_critter_id}' AND valid_to IS NULL)`);
 
       const link_res = await client.query(
         `SELECT bctw.link_collar_to_animal('${id}', '${link_collar_id}', '${link_critter_id}', '${data_start}', '${data_start}', ${formattedEnd})`

--- a/bctw-api/src/routes.ts
+++ b/bctw-api/src/routes.ts
@@ -27,6 +27,8 @@ const ROUTES = {
   attachDevice: '/attach-device',
   unattachDevice: '/unattach-device',
   updateDataLife: '/update-data-life',
+  getDeployments: '/get-deployments',
+  updateDeployment: '/update-deployment',
   // permissions
   getPermissionRequests: '/permission-request',
   getGrantedPermissionHistory: '/permission-history',
@@ -91,6 +93,8 @@ const ROUTE_AUDIENCES: { [key in IRouteKey]?: Audience[] } = {
   [ROUTES.deployDevice]: ['SIMS'], // Only SIMS users may do this.
   [ROUTES.health]: ['ANY'],
   [ROUTES.notFound]: ['ANY'],
+  [ROUTES.getDeployments]: ['ANY'],
+  [ROUTES.updateDeployment]: ['ANY']
 };
 
 export { ROUTES, IRouteKey, IRoute, ROUTE_AUDIENCES };

--- a/bctw-api/src/server.ts
+++ b/bctw-api/src/server.ts
@@ -49,6 +49,8 @@ export const app = express()
   .post(ROUTES.attachDevice, api.attachDevice)
   .post(ROUTES.unattachDevice, api.unattachDevice)
   .post(ROUTES.updateDataLife, api.updateDataLife)
+  .get(ROUTES.getDeployments, api.getDeployments)
+  .patch(ROUTES.updateDeployment, api.updateDeploymentTimespan)
   // permissions
   .get(ROUTES.getPermissionRequests, api.getPermissionRequests)
   .get(ROUTES.getGrantedPermissionHistory, api.getGrantedPermissionHistory)

--- a/bctw-api/src/start.ts
+++ b/bctw-api/src/start.ts
@@ -65,6 +65,8 @@ import {
   getCollarAssignmentHistory,
   unattachDevice,
   updateDataLife,
+  updateDeploymentTimespan,
+  getDeployments
 } from './apis/attachment_api';
 import {
   getOnboardingRequests,
@@ -199,4 +201,6 @@ export {
   submitOnboardingRequest,
   fetchVendorTelemetryData,
   importTelemetry,
+  updateDeploymentTimespan,
+  getDeployments
 };

--- a/bctw-api/src/types/attachment.ts
+++ b/bctw-api/src/types/attachment.ts
@@ -25,7 +25,13 @@ interface IChangeDataLifeProps extends Pick<IRemoveDeviceProps, 'assignment_id'>
   data_life_end: Date | string;
 }
 
+interface IChangeDeploymentProps {
+  deployment_id: string;
+  attachment_start: Date | string;
+  attachment_end: Date | string;
+}
+
 // specifically for the bulk handlers, when a 'historical' attachment can be imported
 type HistoricalAttachmentProps = IAttachDeviceProps & IDataLifeEndProps;
 
-export type { IAttachDeviceProps, IRemoveDeviceProps, IChangeDataLifeProps, HistoricalAttachmentProps };
+export type { IAttachDeviceProps, IRemoveDeviceProps, IChangeDataLifeProps, HistoricalAttachmentProps, IChangeDeploymentProps };


### PR DESCRIPTION
Note that this is based off #74, so please merge that first.

This contains a minor fix for the SQL statement inserting rows into user animal assignment table on bulk imports. Modified to check whether a valid assignment for that user and critter exists already, skipping the insert if it does. 