### PR TITLE
SIMSBIOHUB-239: Keycloak Service Token Auth

### DIFF
--- a/bctw-api/src/apis/collar_api.ts
+++ b/bctw-api/src/apis/collar_api.ts
@@ -317,11 +317,14 @@ const getCollarVendors = async (
   req: Request,
   res: Response
 ): Promise<Response> => {
+  const deprecatedVendors = ['Followit', 'Televilt', 'Telonics'];
   const vendors = await getVendors();
   if (!vendors) {
     return res.status(500).send('failed to retrieve collar vendors');
   } else {
-    return res.status(200).send(vendors);
+    return res
+      .status(200)
+      .send(vendors.filter((vendor) => !deprecatedVendors.includes(vendor)));
   }
 };
 

--- a/bctw-api/src/apis/collar_api.ts
+++ b/bctw-api/src/apis/collar_api.ts
@@ -45,7 +45,6 @@ const upsertCollar = async function (
   if (isError) {
     bulkResp.errors.push({ row: '', error: error.message, rownum: 0 });
   } else {
-    const rowResults = getRowResults(result, fn_upsert_collar);
     createBulkResponse(bulkResp, getRowResults(result, fn_upsert_collar)[0]);
   }
   return res.status(getStatusFromBulkRes(bulkResp)).send(bulkResp);

--- a/bctw-api/src/apis/deployment_api.ts
+++ b/bctw-api/src/apis/deployment_api.ts
@@ -24,19 +24,20 @@ const deployDeviceDb = async (data: IDeployDevice, user: string) => {
   try {
     await client.query('BEGIN');
 
-    // Check if critter exists and is already assigned to someone
-    const critterCheckSql = `SELECT * FROM bctw_dapi_v1.get_critter_user_assignment_status('${user}', '${data.critter_id}')`;
-    const critterCheckResult = getRowResults(
-      await client.query(critterCheckSql),
-      'get_critter_user_assignment_status'
-    );
-    if (!critterCheckResult) {
-      // 403 error
-      throw apiError.forbidden(
-        'You do not have permission to manage the critter with critter id ' +
-          data.critter_id
-      );
-    }
+    // ! Removing this check and giving SIMS more authority
+    // // Check if critter exists and is already assigned to someone
+    // const critterCheckSql = `SELECT * FROM bctw_dapi_v1.get_critter_user_assignment_status('${user}', '${data.critter_id}')`;
+    // const critterCheckResult = getRowResults(
+    //   await client.query(critterCheckSql),
+    //   'get_critter_user_assignment_status'
+    // );
+    // if (!critterCheckResult) {
+    //   // 403 error
+    //   throw apiError.forbidden(
+    //     'You do not have permission to manage the critter with critter id ' +
+    //       data.critter_id
+    //   );
+    // }
 
     // Assign critter to user
     const assignCritterSql = `INSERT INTO bctw.user_animal_assignment 

--- a/bctw-api/src/apis/deployment_api.ts
+++ b/bctw-api/src/apis/deployment_api.ts
@@ -58,7 +58,7 @@ const deployDeviceDb = async (data: IDeployDevice, user: string) => {
     )[0];
 
     // Try to link collar to critter
-    const linkCritterSql = `SELECT bctw.link_collar_to_animal('${user}', '${collar_id}', '${data.critter_id}', '${data.data_start}', '${data.data_start}', '${data.data_end}', '${data.data_end}')`;
+    const linkCritterSql = `SELECT bctw.link_collar_to_animal('${user}', '${collar_id}', '${data.critter_id}', '${data.data_start}', '${data.data_start}', '${data.data_end}')`;
     const linkCritterResult = getRowResults(
       await client.query(linkCritterSql),
       'link_collar_to_animal'
@@ -71,6 +71,7 @@ const deployDeviceDb = async (data: IDeployDevice, user: string) => {
     }
     // Commit transaction
     await client.query('COMMIT');
+    return linkCritterResult;
   } catch (e) {
     console.log(e);
     await client.query('ROLLBACK');

--- a/bctw-api/src/apis/onboarding_api.ts
+++ b/bctw-api/src/apis/onboarding_api.ts
@@ -214,7 +214,7 @@ const signupUser = async (req: UserRequest): Promise<void> => {
     user,
     eUserRole.user,
   ]);
-  const { result, error, isError } = await query(sql, '', true);
+  const { error, isError } = await query(sql, '', true);
   if (isError) {
     throw new Error(error.message);
   }

--- a/bctw-api/src/apis/onboarding_api.ts
+++ b/bctw-api/src/apis/onboarding_api.ts
@@ -202,9 +202,9 @@ const getFiles = async (
 };
 
 const signupUser = async (req: UserRequest): Promise<void> => {
-  const { keycloakId, domain, email, givenName, familyName } = req.user;
+  const { keycloak_guid, domain, email, givenName, familyName } = req.user;
   const user = {
-    [domain]: keycloakId,
+    [domain]: keycloak_guid,
     email,
     firstname: givenName,
     lastname: familyName,
@@ -235,7 +235,7 @@ const signup = async (
 
   // Confirm successful registration
   const registered = await getRegistrationStatus(
-    (req as UserRequest).user.keycloakId
+    (req as UserRequest).user.keycloak_guid
   );
   if (!registered) {
     res.status(500).send('Failed to register user');

--- a/bctw-api/src/auth/authentication.ts
+++ b/bctw-api/src/auth/authentication.ts
@@ -5,7 +5,6 @@ import {
   BCTW_AUD,
   KEYCLOAK_HOST,
   KEYCLOAK_REALM,
-  SIMS_AUD,
   SIMS_SERVICE_AUD,
   critterbase,
 } from '../constants';
@@ -78,8 +77,6 @@ export const authenticateRequest = (
       const origin =
         decoded.aud === BCTW_AUD
           ? 'BCTW'
-          : decoded.aud === SIMS_AUD
-          ? 'SIMS'
           : decoded.aud === SIMS_SERVICE_AUD
           ? 'SIMS_SERVICE'
           : null;

--- a/bctw-api/src/auth/authorization.ts
+++ b/bctw-api/src/auth/authorization.ts
@@ -9,9 +9,9 @@ import { UserRequest } from '../types/userRequest';
 import { ROUTE_AUDIENCES } from '../routes';
 
 export const getRegistrationStatus = async (
-  keycloakId: string
+  keycloak_guid: string
 ): Promise<boolean> => {
-  const sql = constructFunctionQuery(fn_get_user_id, [keycloakId]);
+  const sql = constructFunctionQuery(fn_get_user_id, [keycloak_guid]);
   const { result } = await query(sql);
   const isRegistered =
     typeof getRowResults(result, fn_get_user_id, true) === 'number';
@@ -25,9 +25,9 @@ export const authorizeRequest = async (
   next: NextFunction
 ): Promise<void> => {
   const user = (req as UserRequest).user;
-  const { origin, keycloakId } = user;
+  const { origin, keycloak_guid } = user;
 
-  user.registered = await getRegistrationStatus(keycloakId);
+  user.registered = await getRegistrationStatus(keycloak_guid);
 
   // Registered BCTW users can access all routes
   if (user.registered && origin === 'BCTW') {

--- a/bctw-api/src/auth/authorization.ts
+++ b/bctw-api/src/auth/authorization.ts
@@ -46,14 +46,15 @@ export const authorizeRequest = async (
     return next();
   }
 
-  // If the user's origin isn't included, or the user is from BCTW or SIMS and isn't registered, return a forbidden error
+  // If the user's origin isn't included, or the user is from BCTW and isn't registered, return a forbidden error
   if (
     !allowedAudiences.includes(origin) ||
-    (!user.registered && (origin === 'BCTW' || origin === 'SIMS'))
+    (!user.registered && origin === 'BCTW')
   ) {
     res.status(403).send('Forbidden');
     return;
   }
 
+  // Otherwise, the user is authorized
   next();
 };

--- a/bctw-api/src/auth/keycloak.ts
+++ b/bctw-api/src/auth/keycloak.ts
@@ -1,24 +1,21 @@
 import axios from 'axios';
 import { KEYCLOAK_HOST, KEYCLOAK_REALM } from '../constants';
 import { apiError } from '../utils/error';
+import { URLSearchParams } from 'url';
 
 const keycloakTokenHost = `${KEYCLOAK_HOST}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`;
 
 export const getKeycloakToken = async (): Promise<string> => {
   try {
-    const { data } = await axios.post(
-      keycloakTokenHost,
-      JSON.stringify({
-        client_id: process.env.KEYCLOAK_ADMIN_USERNAME,
-        grant_type: 'client_credentials',
-        client_secret: process.env.KEYCLOAK_ADMIN_PASSWORD,
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-      }
-    );
+    const params = new URLSearchParams();
+    params.append('grant_type', 'client_credentials');
+    params.append('client_id', process.env.KEYCLOAK_ADMIN_USERNAME ?? '');
+    params.append('client_secret', process.env.KEYCLOAK_ADMIN_PASSWORD ?? '');
+    const { data } = await axios.post(keycloakTokenHost, params, {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    });
     return data.access_token;
   } catch (error) {
     console.log(error);

--- a/bctw-api/src/auth/keycloak.ts
+++ b/bctw-api/src/auth/keycloak.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import { KEYCLOAK_HOST, KEYCLOAK_REALM } from '../constants';
+import { apiError } from '../utils/error';
+
+const keycloakTokenHost = `${KEYCLOAK_HOST}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`;
+
+export const getKeycloakToken = async (): Promise<string> => {
+  try {
+    const { data } = await axios.post(
+      keycloakTokenHost,
+      JSON.stringify({
+        client_id: process.env.KEYCLOAK_ADMIN_USERNAME,
+        grant_type: 'client_credentials',
+        client_secret: process.env.KEYCLOAK_ADMIN_PASSWORD,
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      }
+    );
+    return data.access_token;
+  } catch (error) {
+    console.log(error);
+    throw apiError.serverIssue();
+  }
+};

--- a/bctw-api/src/constants.ts
+++ b/bctw-api/src/constants.ts
@@ -48,7 +48,6 @@ const MORTALITY_SMS =
   'e0ad95d9-56f3-4ad5-bab9-85c31ddef926';
 
 const BCTW_AUD = process.env.BCTW_AUD ?? '';
-const SIMS_AUD = process.env.SIMS_AUD ?? '';
 const SIMS_SERVICE_AUD = process.env.SERVICE_AUD ?? '';
 
 const critterbase = axios.create({
@@ -79,6 +78,5 @@ export {
   KEYCLOAK_HOST,
   KEYCLOAK_REALM,
   BCTW_AUD,
-  SIMS_AUD,
   SIMS_SERVICE_AUD,
 };

--- a/bctw-api/src/database/requests.ts
+++ b/bctw-api/src/database/requests.ts
@@ -36,7 +36,7 @@ const getFilterFromRequest = (
  * @returns the identifier as a string if it exists, or undefined -> keycloak GUUID
  */
 const getUserIdentifier = (req: Request): string | undefined => {
-  return String((req as UserRequest).user.keycloakId) ?? undefined;
+  return String((req as UserRequest).user.keycloak_guid) ?? undefined;
 };
 
 /**
@@ -51,7 +51,7 @@ const getUserIdentifierDomain = (
   }
   return [
     (req as UserRequest).user.domain,
-    (req as UserRequest).user.keycloakId,
+    (req as UserRequest).user.keycloak_guid,
   ];
 };
 

--- a/bctw-api/src/import/bulk_handlers.ts
+++ b/bctw-api/src/import/bulk_handlers.ts
@@ -7,7 +7,7 @@ import {
 import { IAnimal } from '../types/animal';
 import { ICollar } from '../types/collar';
 import { IBulkResponse, IImportError } from '../types/import_types';
-const getStatusFromBulkRes = (br: IBulkResponse) => {
+const getStatusFromBulkRes = (br: IBulkResponse): number => {
   // 200 - success / 207 - partial success / 400 - failure
   if (br.results.length) {
     return br.errors.length ? 207 : 200;

--- a/bctw-api/src/import/csv.ts
+++ b/bctw-api/src/import/csv.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from 'express';
 import {
-  constructFunctionQuery,
   getRowResults,
   query,
 } from '../database/query';
@@ -20,7 +19,7 @@ import {
 import { Workbook } from 'exceljs';
 import { ExtendedWorksheet } from '../types/xlsx_types';
 import { getFiles } from '../apis/onboarding_api';
-import { S_API, critterbase } from '../constants';
+import { critterbase } from '../constants';
 import { GenericVendorTelemetry } from '../types/vendor';
 import {
   validateAnimalDeviceData,

--- a/bctw-api/src/import/validation.ts
+++ b/bctw-api/src/import/validation.ts
@@ -1,6 +1,5 @@
 import { vectronicRecordExists } from '../apis/vendor/vectronic';
 import { doesVendorDeviceExist } from '../apis/vendor/vendor_helpers';
-import { S_API } from '../constants';
 import {
   constructFunctionQuery,
   getRowResults,

--- a/bctw-api/src/routes.ts
+++ b/bctw-api/src/routes.ts
@@ -84,7 +84,7 @@ type IRoute = typeof ROUTES[IRouteKey];
 
 const ROUTE_AUDIENCES: { [key in IRouteKey]?: Audience[] } = {
   [ROUTES.getTemplate]: ['ANY'],
-  [ROUTES.getCollarVendors]: ['SIMS'],
+  [ROUTES.getCollarVendors]: ['SIMS_SERVICE'],
   [ROUTES.signup]: ['SIMS_SERVICE'], // Only the SIMS service can signup users directly.
   [ROUTES.getUserOnboardStatus]: ['ANY'], // Open to all common-realm users.
   [ROUTES.submitOnboardingRequest]: ['ANY'],

--- a/bctw-api/src/routes.ts
+++ b/bctw-api/src/routes.ts
@@ -88,7 +88,7 @@ const ROUTE_AUDIENCES: { [key in IRouteKey]?: Audience[] } = {
   [ROUTES.signup]: ['SIMS_SERVICE'], // Only the SIMS service can signup users directly.
   [ROUTES.getUserOnboardStatus]: ['ANY'], // Open to all common-realm users.
   [ROUTES.submitOnboardingRequest]: ['ANY'],
-  [ROUTES.deployDevice]: ['SIMS'], // Only SIMS users may do this.
+  [ROUTES.deployDevice]: ['SIMS_SERVICE'], // Only SIMS service may do this.
   [ROUTES.health]: ['ANY'],
   [ROUTES.notFound]: ['ANY'],
 };

--- a/bctw-api/src/server.ts
+++ b/bctw-api/src/server.ts
@@ -8,7 +8,7 @@ import { finalizeImport, importXlsx, getTemplateFile } from './import/csv';
 import listenForTelemetryAlerts from './database/notify';
 import { pgPool } from './database/pg';
 import { critterbaseRouter } from './apis/critterbaseRouter';
-import { authenticateRequest, forwardToken } from './auth/authentication';
+import { authenticateRequest, forwardUser } from './auth/authentication';
 import { deployDevice } from './apis/deployment_api';
 import { authorizeRequest } from './auth/authorization';
 import { ROUTES } from './routes';
@@ -25,7 +25,7 @@ export const app = express()
   .use(express.json())
   .use(authenticateRequest)
   .use(authorizeRequest)
-  .use(forwardToken)
+  .use(forwardUser)
   .use(ROUTES.critterbase, critterbaseRouter)
   // map
   .get(ROUTES.getCritters, api.getDBCritters)

--- a/bctw-api/src/types/userRequest.ts
+++ b/bctw-api/src/types/userRequest.ts
@@ -6,7 +6,7 @@ export interface UserRequest extends Request {
   user: {
     origin: Audience;
     domain: 'idir' | 'bceid';
-    keycloakId: string;
+    keycloak_guid: string;
     email: string;
     givenName: string;
     familyName: string;

--- a/bctw-api/tests/apis/collar_api.test.ts
+++ b/bctw-api/tests/apis/collar_api.test.ts
@@ -1,4 +1,3 @@
-import { deleteCollar } from '../../src/apis/collar_api';
 import { request } from '../utils/constants';
 import { mockQuery, queryReturn } from './test_helpers';
 


### PR DESCRIPTION
This PR restructures the auth to accept a SIMS service token, instead of a SIMS user. The SIMS service account will be treated as an admin user, so that in future, it can do more advanced operations, such as granting permissions to specific sims users, etc. All device deployments from SIMS will be held under the SIMS service as a user in bctw.

This PR also changes how BCTW interacts with Critterbase. Similarly, Critterbase will also switch over to the keycloak service account pattern. The middleware in bctw that used to forward the user token, will now forward a user header instead and send requests with a BCTW service token.