### PR TITLE
Duplicate WLH ID fixes and others

### DIFF
--- a/bctw-api/src/import/import_helpers.ts
+++ b/bctw-api/src/import/import_helpers.ts
@@ -205,7 +205,7 @@ const determineExistingAnimal = async (
   return critterbase_critters.result.rows.map(c => ({critter_id: c.critter_id, wlh_id: c.wlh_id }));
 };
 
-const markingInferDuplicate = (old_marking: IMarking, new_marking: MarkingUpsert): boolean => {
+const markingInferDuplicate = (old_marking: IMarking | MarkingUpsert, new_marking: MarkingUpsert): boolean => {
   const coreFeaturesSame = (!!new_marking.primary_colour && old_marking.primary_colour === new_marking.primary_colour) ||
           (!!new_marking.identifier && old_marking.identifier === new_marking.identifier);
   const locationAndTypeSame = (old_marking.body_location === new_marking.body_location && old_marking.marking_type === new_marking.marking_type);


### PR DESCRIPTION
* Changes the behavior of the import finalization so that it will examine both the entries in the sheet and entries in CB if applicable to avoid creating duplicates. In the case where multiple new critter rows have the same wlh id in the sheet, it will ensure they are created using the same critter_id.
* Optimizations to the export page are included. It should now avoid fetching enormous amounts of telemetry in one request, instead larger export requests will be chunked into multiple calls to ensure it doesn't crash the call stack.