### PR TITLE
SIMSBIOHUB295 View Telemetry

### DIFF
--- a/bctw-api/src/apis/map_api.ts
+++ b/bctw-api/src/apis/map_api.ts
@@ -228,7 +228,8 @@ const getCritterTracks = async (
       jsonb_build_object (
         'type', 'Feature',
         'properties', json_build_object(
-          'critter_id', critter_id
+          'critter_id', critter_id,
+          'deployment_id', deployment_id
         ),
         'geometry', st_asGeoJSON(st_makeLine(geom ORDER BY date_recorded ASC))::jsonb
       ) AS "geojson"
@@ -238,6 +239,7 @@ const getCritterTracks = async (
       critter_id IS NOT NULL AND
       st_asText(geom) <> 'POINT(0 0)'
     GROUP BY
+      deployment_id,
       critter_id;
   `;
 

--- a/bctw-api/src/server.ts
+++ b/bctw-api/src/server.ts
@@ -27,8 +27,8 @@ export const app = express()
   .use(forwardUser)
   .use(ROUTES.critterbase, authorize(), critterbaseRouter)
   // map
-  .get(ROUTES.getCritters, authorize(), api.getDBCritters)
-  .get(ROUTES.getCritterTracks, authorize(), api.getCritterTracks)
+  .get(ROUTES.getCritters, authorize('SIMS_SERVICE'), api.getDBCritters)
+  .get(ROUTES.getCritterTracks, authorize('SIMS_SERVICE'), api.getCritterTracks)
   .get(ROUTES.getPingsEstimate, authorize(), api.getPingsEstimate)
   // animals
   .get(ROUTES.getAnimals, authorize(), api.getAnimals)


### PR DESCRIPTION
This is a change to support SIMS viewing telemetry grouped by deployment in the frontend map view.

All I had to change in the API here is authentication for the relevant routes as well as including and grouping by the deployment_id in the tracks. Without this it just makes one huge line through all points which winds up looking pretty weird if the deployments overlap at all. There is also a change to get_telemetry in the db for this.