### PR TITLE
Remove one-week filter on vectronic and lotek data retrieval

### DIFF
--- a/data-collector/scripts/lotek.ts
+++ b/data-collector/scripts/lotek.ts
@@ -81,7 +81,7 @@ const insertAPICollarData = async function (collar: ICollar) {
  */
 const iterateCollars = async function (collar: ICollar) {
   const weekAgo = dayjs().subtract(7, "d").format("YYYY-MM-DDTHH:mm:ss");
-  const url = `${lotekUrl}/gps?deviceId=${collar.nDeviceID}&dtStart=${weekAgo}`;
+  const url = `${lotekUrl}/gps?deviceId=${collar.nDeviceID}`;
 
   // Send request to the API
   const { body, error } = await needle("get", url, tokenConfig);

--- a/data-collector/scripts/vectronic.ts
+++ b/data-collector/scripts/vectronic.ts
@@ -48,7 +48,7 @@ const iterateCollars = function (collar, callback) {
   const key = collar.collarkey;
   const id = collar.idcollar;
   const weekAgo = moment().subtract(7, "d").format("YYYY-MM-DDTHH:mm:ss");
-  const url = `${apiUrl}/${id}/gps?collarkey=${key}&afterScts=${weekAgo}`;
+  const url = `${apiUrl}/${id}/gps?collarkey=${key}`;
 
   // console.log(`Fetching data for ${id}`);
 


### PR DESCRIPTION
Data retrievals were previously filtered to include data from within the previous week. If collars were uploaded more than week after being deployed, some data are missing. This PR fixes the issue by retrieving all telemetry data in each cronjob.