### PR TITLE
Add CRUD Operations to Deployment Controller for SIMS

### DIFF
--- a/bctw-api/src/apis/deployment_api.ts
+++ b/bctw-api/src/apis/deployment_api.ts
@@ -5,22 +5,16 @@ import { ICollar } from '../types/collar';
 import { getUserIdentifier } from '../database/requests';
 import { apiError } from '../utils/error';
 import { formatNullableSqlValue } from '../utils/formatting';
-
-interface IDeployDevice extends ICollar {
-  deployment_id: string;
-  critter_id: string;
-  attachment_start: Date;
-  attachment_end: Date;
-}
+import { ICreateDeployment } from '../types/deployment';
 
 /**
  * Provides a mechanism for importing and linking telemetry devices and critters to a user.
  * Aims to avoid collisions on any existing critters or devices by checking existing records.
  *
- * @param {IDeployDevice} data
+ * @param {ICreateDeployment} data
  * @param {string} user
  */
-const deployDeviceDb = async (data: IDeployDevice, user: string) => {
+const deployDeviceDb = async (data: ICreateDeployment, user: string) => {
   const client = await pgPool.connect(); //Using client directly here, since we want this entire procedure to be wrapped in a transaction.
 
   try {
@@ -38,6 +32,8 @@ const deployDeviceDb = async (data: IDeployDevice, user: string) => {
       // 400 error
       throw apiError.requiredProperty('device_id');
     }
+
+    // Check if the device conflicts with an existing deployment
 
     const collarSql = `SELECT bctw.get_device_id_for_bulk_import('${user}', '${JSON.stringify(
       data

--- a/bctw-api/src/controllers/collar-controller.ts
+++ b/bctw-api/src/controllers/collar-controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { CollarService } from '../services/collar-service';
-import { UpdateCollarRequest } from '../types/collar';
+import { UpdateCollar } from '../types/collar';
 import { Controller } from './base-controller';
 
 /**
@@ -42,7 +42,7 @@ export class CollarController extends Controller {
    */
   updateCollar = async (req: Request, res: Response): Promise<Response> => {
     try {
-      const data = UpdateCollarRequest.parse(req.body);
+      const data = UpdateCollar.parse(req.body);
 
       const keycloak_guid = this.service.getUserIdentifier(req);
 

--- a/bctw-api/src/controllers/deployment-controller.ts
+++ b/bctw-api/src/controllers/deployment-controller.ts
@@ -1,7 +1,15 @@
 import { Request, Response } from 'express';
 import { DeploymentService } from '../services/deployment-service';
-import { IdsSchema } from '../types/deployment';
+import {
+  CreateDeploymentArraySchema,
+  CreateDeploymentSchema,
+  DeleteDeploymentSchema,
+  Deployment,
+  IdsSchema,
+  UpdateDeploymentSchema,
+} from '../types/deployment';
 import { Controller } from './base-controller';
+import { CollarService } from '../services/collar-service';
 
 /**
  * Includes endpoints for mutating and retrieving deployment (aka: collar animal assignment) records.
@@ -19,6 +27,7 @@ import { Controller } from './base-controller';
  */
 export class DeploymentController extends Controller {
   service: DeploymentService;
+  collarService: CollarService;
 
   /**
    * Instantiates an instance of DeploymentController and injects dependencies.
@@ -47,6 +56,142 @@ export class DeploymentController extends Controller {
       const deployments = await this.service.getDeployments(deployment_ids);
 
       return res.status(200).json(deployments);
+    } catch (err) {
+      return this.handleApiError(err, res);
+    }
+  };
+
+  /**
+   * Creates a new deployment by inserting into both the collar table and collar_animal_assignment
+   *
+   * @async
+   * @memberof DeploymentController
+   * @param {Request} req
+   * @param {Response} res
+   * @returns {Promise<Response>}
+   */
+  createDeployments = async (
+    req: Request,
+    res: Response
+  ): Promise<Response> => {
+    try {
+      const keycloak_guid = this.service.getUserIdentifier(req);
+
+      // Validate the request body
+      const deploymentsForInsert = CreateDeploymentArraySchema.parse(req.body);
+
+      const results: Deployment[] = [];
+
+      for (const deployment of deploymentsForInsert) {
+        const {
+          device_id,
+          device_make,
+          device_model,
+          frequency,
+          frequency_unit,
+          ...deploymentDetails
+        } = deployment;
+
+        // Step 1: Create a collar record for the new deployment
+        const collar = await this.collarService.createCollar(
+          {
+            device_id,
+            device_make,
+            device_model,
+            frequency,
+            frequency_unit,
+          },
+          keycloak_guid
+        );
+
+        // Step 2: Create a deployment record referencing the collar record
+        const response = await this.service.createDeployment({
+          ...deploymentDetails,
+          collar_id: collar.collar_transaction_id,
+        });
+
+        results.push(response);
+      }
+
+      return res.status(200).json(results);
+    } catch (err) {
+      return this.handleApiError(err, res);
+    }
+  };
+
+  /**
+   * Updates an existing deployment
+   *
+   * @async
+   * @memberof DeploymentController
+   * @param {Request} req
+   * @param {Response} res
+   * @returns {Promise<Response>}
+   */
+  updateDeployment = async (req: Request, res: Response): Promise<Response> => {
+    try {
+      const keycloak_guid = this.service.getUserIdentifier(req);
+
+      // Validate the request body
+      const deploymentForUpdate = UpdateDeploymentSchema.parse(req.body);
+
+      const {
+        device_id,
+        device_make,
+        device_model,
+        frequency,
+        frequency_unit,
+        ...deploymentDetails
+      } = deploymentForUpdate;
+
+      // Step 1: Update the deployment record
+      const { collar_id } = await this.service.updateDeployment(
+        deploymentDetails
+      );
+
+      // Step 2: Update the associated collar record
+      const collar = await this.collarService.updateCollar(
+        {
+          collar_id,
+          device_id,
+          device_make,
+          device_model,
+          frequency,
+          frequency_unit,
+        },
+        keycloak_guid
+      );
+
+      return res.status(200).json(collar);
+    } catch (err) {
+      return this.handleApiError(err, res);
+    }
+  };
+
+  /**
+   * Deletes a deployment
+   *
+   * @async
+   * @memberof DeploymentController
+   * @param {Request} req
+   * @param {Response} res
+   * @returns {Promise<Response>}
+   */
+  deleteDeployment = async (req: Request, res: Response): Promise<Response> => {
+    try {
+      // Validate the request body
+      const { deployment_id } = DeleteDeploymentSchema.parse(req.body);
+
+      // Step 1: Delete the deployment's associated collar_id
+      const deployment = await this.service.getDeploymentById(deployment_id);
+      await this.collarService.deleteCollar({
+        collar_id: deployment.collar_id,
+      });
+
+      // Step 2: Delete the deployment
+      await this.service.deleteDeployment({ deployment_id });
+
+      return res.status(200).json(deployment);
     } catch (err) {
       return this.handleApiError(err, res);
     }

--- a/bctw-api/src/repositories/collar-repository.test.ts
+++ b/bctw-api/src/repositories/collar-repository.test.ts
@@ -1,7 +1,7 @@
 import { Pool } from 'pg';
 import { CollarRepository } from './collar-repository';
 import { Connection } from './util/connection-client';
-import { UpdateCollarRequest } from '../types/collar';
+import { UpdateCollar } from '../types/collar';
 
 describe('CollarRepository', () => {
   let repo: CollarRepository;
@@ -25,7 +25,7 @@ describe('CollarRepository', () => {
 
   describe('updateCollar', () => {
     it('should pass queryBuilder to query method', async () => {
-      const data: UpdateCollarRequest = {
+      const data: UpdateCollar = {
         collar_id: '786db5ed-2b03-4f51-a809-d18a6aa5c6f7',
         device_make: 281,
         device_model: 'Telonics TGW-4570',

--- a/bctw-api/src/repositories/collar-repository.ts
+++ b/bctw-api/src/repositories/collar-repository.ts
@@ -1,4 +1,10 @@
-import { UpdateCollarRequest } from '../types/collar';
+import {
+  CollarSchema,
+  CreateCollar,
+  DeleteCollar,
+  ICollar,
+  UpdateCollar,
+} from '../types/collar';
 import { Repository } from './base-repository';
 
 /**
@@ -12,15 +18,12 @@ export class CollarRepository extends Repository {
   /**
    * Update a collar record.
    *
-   * @param {UpdateCollarRequest} data - The collar data to update.
+   * @param {UpdateCollar} data - The collar data to update.
    * @param {string} userGuid - The guid of the user.
    * @return {*}  {Promise<void>}
    * @memberof CollarRepository
    */
-  async updateCollar(
-    data: UpdateCollarRequest,
-    userGuid: string
-  ): Promise<void> {
+  async updateCollar(data: UpdateCollar, userGuid: string): Promise<void> {
     const connection = this.getConnection();
     const knex = this.getKnex();
 
@@ -54,6 +57,75 @@ export class CollarRepository extends Repository {
       }
 
       await connection.transaction.commit();
+    } catch (error) {
+      await connection.transaction.rollback();
+      throw error;
+    }
+  }
+
+  /**
+   * Create a collar record.
+   *
+   * @param {CreateCollar} collar - The collar data to create.
+   * @param {string} userGuid - The guid of the user.
+   * @return {*}  {Promise<void>}
+   * @memberof CollarRepository
+   */
+  async createCollar(collar: CreateCollar, userGuid: string): Promise<ICollar> {
+    const connection = this.getConnection();
+    const knex = this.getKnex();
+
+    try {
+      await connection.transaction.begin();
+
+      const queryBuilder = knex('collar')
+        .insert({
+          device_id: collar.device_id,
+          device_make: collar.device_make,
+          device_model: collar.device_model,
+          frequency: collar.frequency,
+          frequency_unit: collar.frequency_unit,
+          updated_at: 'now()',
+          updated_by_user_id: knex.raw(`bctw.get_user_id($$${userGuid}$$)`),
+        })
+        .returning('*');
+
+      const response = await connection.query<ICollar>(queryBuilder);
+
+      await connection.transaction.commit();
+
+      return response.rows[0];
+    } catch (error) {
+      await connection.transaction.rollback();
+      throw error;
+    }
+  }
+
+  /**
+   * Delete a collar record.
+   *
+   * @param {DeleteCollar} collar - The collar data to delete.
+   * @return {*}  {Promise<void>}
+   * @memberof CollarRepository
+   */
+  async deleteCollar(collar: DeleteCollar): Promise<ICollar> {
+    const connection = this.getConnection();
+    const knex = this.getKnex();
+
+    try {
+      await connection.transaction.begin();
+
+      const queryBuilder = this.getKnex()
+        .table('collar_animal_assignment')
+        .where('deployment_id', collar.collar_id)
+        .delete()
+        .returning('*');
+
+      const response = await connection.query<ICollar>(queryBuilder);
+
+      await connection.transaction.commit();
+
+      return response.rows[0];
     } catch (error) {
       await connection.transaction.rollback();
       throw error;

--- a/bctw-api/src/repositories/deployment-repository.ts
+++ b/bctw-api/src/repositories/deployment-repository.ts
@@ -1,5 +1,10 @@
 import SQL from 'sql-template-strings';
-import { Deployment } from '../types/deployment';
+import {
+  DeleteDeployment,
+  Deployment,
+  ICreateDeployment,
+  UpdateDeployment,
+} from '../types/deployment';
 import { Repository } from './base-repository';
 
 /**
@@ -11,19 +16,15 @@ import { Repository } from './base-repository';
  */
 export class DeploymentRepository extends Repository {
   /**
-   * Get active deployment (aka: collar animal assignment) records by deployment_ids.
+   * Creates the base query for retrieving deployments.
    *
-   * Note: A deployment is considered active if the valid_to field is null for both the collar_animal_assignment and
-   * collar records.
-   *
-   * @param {string[]} deployment_ids - Array of deployment_ids.
-   * @return {*}  {Promise<Deployment[]>}
-   * @memberof DeploymentRepository
+   * @param {string[] | undefined} deploymentIds - Optional array of deployment IDs to filter.
+   * @param {string | undefined} deploymentId - Optional single deployment ID to filter.
+   * @return {SQL} The base SQL query.
    */
-  async getDeployments(deployment_ids: string[]): Promise<Deployment[]> {
-    const connection = this.getConnection();
-
-    const sqlStatement = SQL`
+  _getDeploymentBaseQuery() {
+    // Base query without specific filters
+    return SQL`
       SELECT 
         collar_animal_assignment.assignment_id,
         collar_animal_assignment.collar_id,
@@ -47,15 +48,117 @@ export class DeploymentRepository extends Repository {
       LEFT JOIN 
         collar ON collar_animal_assignment.collar_id = collar.collar_id
       WHERE 
-        collar_animal_assignment.deployment_id = ANY (${deployment_ids}::uuid[])
-      AND
         collar_animal_assignment.valid_to IS NULL
       AND
-        collar.valid_to IS NULL;
+        collar.valid_to IS NULL
     `;
+  }
+
+  /**
+   * Get active deployment (aka: collar animal assignment) records by deployment_ids.
+   *
+   * Note: A deployment is considered active if the valid_to field is null for both the collar_animal_assignment and
+   * collar records.
+   *
+   * @param {string[]} deploymentIds - Array of deploymentIds.
+   * @return {*}  {Promise<Deployment[]>}
+   * @memberof DeploymentRepository
+   */
+  async getDeployments(deploymentIds: string[]): Promise<Deployment[]> {
+    const connection = this.getConnection();
+
+    const sqlStatement = this._getDeploymentBaseQuery();
+
+    sqlStatement.append(
+      SQL` AND collar_animal_assignment.deployment_id = ANY (${deploymentIds}::uuid[]);`
+    );
 
     const res = await connection.query<Deployment>(sqlStatement);
 
     return res.rows;
+  }
+
+  /**
+   * Get active deployment record by deployment_id.
+   *
+   * @param {string} deploymentId - Deployment ID.
+   * @return {*}  {Promise<Deployment>}
+   * @memberof DeploymentRepository
+   */
+  async getDeploymentById(deploymentId: string): Promise<Deployment> {
+    const connection = this.getConnection();
+
+    const sqlStatement = this._getDeploymentBaseQuery();
+
+    sqlStatement.append(
+      SQL` AND collar_animal_assignment.deployment_id = ${deploymentId};`
+    );
+
+    const res = await connection.query<Deployment>(sqlStatement);
+
+    // TODO: Verify that multiple records won't be returned?
+    return res.rows[0];
+  }
+
+  /**
+   * Create a new deployment
+   *
+   * @param {ICreateDeployment} deployment
+   * @return {*}  {Promise<Deployment>}
+   * @memberof DeploymentRepository
+   */
+  async createDeployment(deployment: ICreateDeployment): Promise<Deployment> {
+    const connection = this.getConnection();
+
+    const sqlStatement = SQL`
+      INSERT INTO collar_animal_assignment (collar_id, critter_id, deployment_id)
+      VALUES (${deployment.collar_id}, ${deployment.critter_id}, ${deployment.deployment_id});
+    `;
+
+    const res = await connection.query<Deployment>(sqlStatement);
+
+    return res.rows[0];
+  }
+
+  /**
+   * Update an existing deployment
+   *
+   * @param {UpdateDeployment} deployment
+   * @return {*}  {Promise<Deployment>}
+   * @memberof DeploymentRepository
+   */
+  async updateDeployment(deployment: UpdateDeployment): Promise<Deployment> {
+    const connection = this.getConnection();
+
+    const sqlStatement = this.getKnex()
+      .table('collar_animal_assignment')
+      .update(deployment)
+      .where('deployment_id', deployment.deployment_id)
+      .returning('*');
+
+    const res = await connection.query<Deployment>(sqlStatement);
+
+    return res.rows[0];
+  }
+
+  /**
+   * Delete an existing deployment
+   *
+   * @param {deleteDeployment} deployment
+   * @return {*}  {Promise<Deployment>}
+   * @memberof DeploymentRepository
+   */
+  async deleteDeployment(deployment: DeleteDeployment): Promise<Deployment> {
+    const connection = this.getConnection();
+
+    const sqlStatement = this.getKnex()
+      .table('collar_animal_assignment')
+      .where('deployment_id', deployment.deployment_id)
+      .delete()
+      .returning('*');
+
+    const res = await connection.query<Deployment>(sqlStatement);
+
+    return res.rows[0];
   }
 }

--- a/bctw-api/src/routes.ts
+++ b/bctw-api/src/routes.ts
@@ -75,6 +75,9 @@ const ROUTES = {
   importXlsx: '/import-xlsx',
   importFinalize: '/import-finalize',
   deployDevice: '/deploy-device',
+  // new deployment routes used by sims
+  createDeployments: '/create-deployments',
+  //
   importXML: '/import-xml',
   importTelemetry: '/import-telemetry',
   getCollarKeyX: '/get-collars-keyx',

--- a/bctw-api/src/server.ts
+++ b/bctw-api/src/server.ts
@@ -11,11 +11,10 @@ import { critterbaseRouter } from './apis/critterbaseRouter';
 import { authenticateRequest, forwardUser } from './auth/authentication';
 import { deployDevice } from './apis/deployment_api';
 import { ROUTES } from './routes';
-import {authorize as auth} from './auth/authorization';
+import { authorize as auth } from './auth/authorization';
 
 // the server location for uploaded files
 const upload = multer({ dest: 'bctw-api/build/uploads' });
-
 
 // setup the express server
 export const app = express()
@@ -28,13 +27,89 @@ export const app = express()
   .use(ROUTES.critterbase, critterbaseRouter)
   .get(ROUTES.getTemplate, auth(), getTemplateFile)
 
-  // telemetry
-  .post(ROUTES.deleteManualTelemetry, auth('SIMS_SERVICE'), api.telemetryController.deleteManualTelemetry)
-  .post(ROUTES.deploymentsManualTelemetry, auth('SIMS_SERVICE'), api.telemetryController.getManualTelemetryByDeploymentIds)
-  .post(ROUTES.manualTelemetry, auth('SIMS_SERVICE'), api.telemetryController.createManualTelemetry)
-  .patch(ROUTES.manualTelemetry, auth('SIMS_SERVICE'), api.telemetryController.updateManualTelemetry)
-  .post(ROUTES.deploymentsVendorTelemetry, auth('SIMS_SERVICE'), api.telemetryController.getVendorTelemetryByDeploymentIds)
-  .post(ROUTES.deploymentsManualVendorTelemetry, auth('SIMS_SERVICE'), api.telemetryController.getAllTelemetryByDeploymentIds)
+  // ENDPOINTS USED BY SIMS
+
+  /**
+   * Create a new deployment, which inserts into the collar table and then into collar_animal_deployment.
+   */
+  .post(
+    ROUTES.createDeployments,
+    auth('SIMS_SERVICE'),
+    api.deploymentController.createDeployments
+  )
+
+  /**
+   * Update an existing deployment and associated collar record
+   */
+  .post(
+    ROUTES.updateDeployment,
+    auth('SIMS_SERVICE'),
+    api.deploymentController.updateDeployment
+  )
+
+  /**
+   * Delete a deployment and associated collar record
+   */
+  .post(
+    ROUTES.deleteDeployment,
+    auth('SIMS_SERVICE'),
+    api.deploymentController.deleteDeployment
+  )
+
+  /**
+   * Delete a manual telemetry record
+   */
+  .post(
+    ROUTES.deleteManualTelemetry,
+    auth('SIMS_SERVICE'),
+    api.telemetryController.deleteManualTelemetry
+  )
+
+  /**
+   * Get manual telemetry records for a set of deployment ids
+   */
+  .post(
+    ROUTES.deploymentsManualTelemetry,
+    auth('SIMS_SERVICE'),
+    api.telemetryController.getManualTelemetryByDeploymentIds
+  )
+
+  /**
+   * Insert a manual telemetry record
+   */
+  .post(
+    ROUTES.manualTelemetry,
+    auth('SIMS_SERVICE'),
+    api.telemetryController.createManualTelemetry
+  )
+
+  /**
+   * Update a manual telemetry record
+   */
+  .patch(
+    ROUTES.manualTelemetry,
+    auth('SIMS_SERVICE'),
+    api.telemetryController.updateManualTelemetry
+  )
+
+  /**
+   * Get vendor-retrieved telemetry by deployment ids
+   */
+  .post(
+    ROUTES.deploymentsVendorTelemetry,
+    auth('SIMS_SERVICE'),
+    api.telemetryController.getVendorTelemetryByDeploymentIds
+  )
+  .post(
+    ROUTES.deploymentsManualVendorTelemetry,
+    auth('SIMS_SERVICE'),
+    api.telemetryController.getAllTelemetryByDeploymentIds
+  )
+
+  /**
+   *
+   *
+   */
 
   // map
   .get(ROUTES.getCritters, auth('SIMS_SERVICE'), api.getDBCritters)
@@ -50,33 +125,73 @@ export const app = express()
   .get(ROUTES.getCollarsAndDeviceIds, auth(), api.getCollarsAndDeviceIds)
   .get(ROUTES.getAssignedCollars, auth(), api.getAssignedCollars)
   .get(ROUTES.getAvailableCollars, auth(), api.getAvailableCollars)
-  .get(ROUTES.getCollarAssignmentHistory, auth(), api.getCollarAssignmentHistory)
+  .get(
+    ROUTES.getCollarAssignmentHistory,
+    auth(),
+    api.getCollarAssignmentHistory
+  )
   .get(ROUTES.getCollarChangeHistory, auth(), api.getCollarChangeHistory)
-  .get(ROUTES.getCollarChangeHistoryByDeviceId, auth('SIMS_SERVICE'),api.getCollarChangeHistoryByDeviceID)
+  .get(
+    ROUTES.getCollarChangeHistoryByDeviceId,
+    auth('SIMS_SERVICE'),
+    api.getCollarChangeHistoryByDeviceID
+  )
   .get(ROUTES.getCollarVendors, auth('SIMS_SERVICE'), api.getCollarVendors)
   .post(ROUTES.upsertCollar, auth('SIMS_SERVICE'), api.upsertCollar)
 
   // collar
-  .patch(ROUTES.updateCollar, auth('SIMS_SERVICE'), api.collarController.updateCollar)
+  .patch(
+    ROUTES.updateCollar,
+    auth('SIMS_SERVICE'),
+    api.collarController.updateCollar
+  )
 
   // animal/device attachment
   .post(ROUTES.attachDevice, auth(), api.attachDevice)
   .post(ROUTES.unattachDevice, auth(), api.unattachDevice)
   .post(ROUTES.updateDataLife, auth(), api.updateDataLife)
-  .get(ROUTES.getDeploymentsByCritterId, auth('SIMS_SERVICE'), api.getDeploymentsByCritterId)
-  .get(ROUTES.getDeploymentsByDeviceId, auth('SIMS_SERVICE'), api.getDeploymentsByDeviceId)
-  .patch(ROUTES.updateDeployment, auth('SIMS_SERVICE'), api.updateDeploymentTimespan)
+  .get(
+    ROUTES.getDeploymentsByCritterId,
+    auth('SIMS_SERVICE'),
+    api.getDeploymentsByCritterId
+  )
+  .get(
+    ROUTES.getDeploymentsByDeviceId,
+    auth('SIMS_SERVICE'),
+    api.getDeploymentsByDeviceId
+  )
+  .patch(
+    ROUTES.updateDeployment,
+    auth('SIMS_SERVICE'),
+    api.updateDeploymentTimespan
+  )
   .delete(ROUTES.deleteDeployment, auth('SIMS_SERVICE'), api.deleteDeployment)
-  
+
   // deployments
-  .post(ROUTES.getDeployments, auth('SIMS_SERVICE'), api.deploymentController.getDeployments)
-  .get(ROUTES.getDeployments, auth('SIMS_SERVICE'), api.deploymentController.getDeployments)
+  .post(
+    ROUTES.getDeployments,
+    auth('SIMS_SERVICE'),
+    api.deploymentController.getDeployments
+  )
+  .get(
+    ROUTES.getDeployments,
+    auth('SIMS_SERVICE'),
+    api.deploymentController.getDeployments
+  )
 
   // permissions
   .get(ROUTES.getPermissionRequests, auth(), api.getPermissionRequests)
-  .get(ROUTES.getGrantedPermissionHistory, auth(), api.getGrantedPermissionHistory)
+  .get(
+    ROUTES.getGrantedPermissionHistory,
+    auth(),
+    api.getGrantedPermissionHistory
+  )
   .post(ROUTES.submitPermissionRequest, auth(), api.submitPermissionRequest)
-  .post(ROUTES.getPermissionRequests, auth(), api.approveOrDenyPermissionRequest)
+  .post(
+    ROUTES.getPermissionRequests,
+    auth(),
+    api.approveOrDenyPermissionRequest
+  )
   // users
   .post(ROUTES.signup, auth('SIMS_SERVICE'), api.signup)
   .get(ROUTES.getUser, auth(), api.getUser)
@@ -86,7 +201,11 @@ export const app = express()
   // onboarding
   .get(ROUTES.getUserOnboardStatus, auth('ANY'), api.getUserOnboardStatus)
   .get(ROUTES.getOnboardingRequests, auth(), api.getOnboardingRequests)
-  .post(ROUTES.submitOnboardingRequest, auth('ANY'), api.submitOnboardingRequest)
+  .post(
+    ROUTES.submitOnboardingRequest,
+    auth('ANY'),
+    api.submitOnboardingRequest
+  )
   .post(ROUTES.handleOnboardingRequest, auth(), api.handleOnboardingRequest)
   // user access
   .get(ROUTES.getUserCritterAccess, auth(), api.getUserCritterAccess)
@@ -107,10 +226,21 @@ export const app = express()
   .post(ROUTES.getAllExportData, auth(), api.getAllExportData)
   .post(ROUTES.importXlsx, auth(), upload.single('validated-file'), importXlsx)
   .post(ROUTES.importFinalize, auth(), finalizeImport)
-  .post(ROUTES.deployDevice, auth('SIMS_SERVICE'), deployDevice)
-  .post(ROUTES.importXML, auth('SIMS_SERVICE'), upload.array('xml'), api.parseVectronicKeyRegistrationXML)
+
+  //
+
+  .post(
+    ROUTES.importXML,
+    auth('SIMS_SERVICE'),
+    upload.array('xml'),
+    api.parseVectronicKeyRegistrationXML
+  )
   .post(ROUTES.importTelemetry, auth(), api.importTelemetry)
-  .get(ROUTES.getCollarKeyX, auth('SIMS_SERVICE'), api.retrieveCollarKeyXRelation)
+  .get(
+    ROUTES.getCollarKeyX,
+    auth('SIMS_SERVICE'),
+    api.retrieveCollarKeyXRelation
+  )
   // vendor
   .post(ROUTES.fetchTelemetry, auth(), api.fetchVendorTelemetryData)
   // delete

--- a/bctw-api/src/services/collar-service.test.ts
+++ b/bctw-api/src/services/collar-service.test.ts
@@ -1,5 +1,5 @@
 import { CollarRepository } from '../repositories/collar-repository';
-import { UpdateCollarRequest } from '../types/collar';
+import { UpdateCollar } from '../types/collar';
 import { CollarService } from './collar-service';
 
 describe('CollarService', () => {
@@ -23,7 +23,7 @@ describe('CollarService', () => {
 
     describe('updateCollar', () => {
       it('should call repo method', async () => {
-        const data: UpdateCollarRequest = {
+        const data: UpdateCollar = {
           collar_id: '786db5ed-2b03-4f51-a809-d18a6aa5c6f7',
           device_make: 281,
           device_model: 'Telonics TGW-4570',

--- a/bctw-api/src/services/collar-service.ts
+++ b/bctw-api/src/services/collar-service.ts
@@ -1,6 +1,11 @@
 import { pgPool } from '../database/pg';
 import { CollarRepository } from '../repositories/collar-repository';
-import { UpdateCollarRequest } from '../types/collar';
+import {
+  CreateCollar,
+  DeleteCollar,
+  ICollar,
+  UpdateCollar,
+} from '../types/collar';
 import { Service } from './base-service';
 
 /**
@@ -27,15 +32,34 @@ export class CollarService extends Service {
   /**
    * Update a collar record by collar_id.
    *
-   * @param {UpdateCollarRequest} data - The collar data to update.
+   * @param {UpdateCollar} data - The collar data to update.
    * @param {string} userGuid - The guid of the user.
    * @return {*}  {Promise<void>}
    * @memberof CollarService
    */
-  async updateCollar(
-    data: UpdateCollarRequest,
-    userGuid: string
-  ): Promise<void> {
+  async updateCollar(data: UpdateCollar, userGuid: string): Promise<void> {
     return this.repository.updateCollar(data, userGuid);
+  }
+
+  /**
+   * Create new collar records
+   *
+   * @param {CreateCollar} collar - The collar data to insert
+   * @return {*}  {Promise<void>}
+   * @memberof CollarService
+   */
+  async createCollar(collar: CreateCollar, userGuid: string): Promise<ICollar> {
+    return this.repository.createCollar(collar, userGuid);
+  }
+
+  /**
+   * Delete new collar records
+   *
+   * @param {DeleteCollar} collar - The collar data to insert
+   * @return {*}  {Promise<void>}
+   * @memberof CollarService
+   */
+  async deleteCollar(collar: DeleteCollar): Promise<ICollar> {
+    return this.repository.deleteCollar(collar);
   }
 }

--- a/bctw-api/src/services/deployment-service.ts
+++ b/bctw-api/src/services/deployment-service.ts
@@ -1,6 +1,11 @@
 import { pgPool } from '../database/pg';
 import { DeploymentRepository } from '../repositories/deployment-repository';
-import { Deployment } from '../types/deployment';
+import {
+  DeleteDeployment,
+  Deployment,
+  ICreateDeployment,
+  UpdateDeployment,
+} from '../types/deployment';
 import { Service } from './base-service';
 
 /**
@@ -27,11 +32,55 @@ export class DeploymentService extends Service {
   /**
    * Get deployment (aka: collar animal assignment) records by deployment_ids.
    *
+   * @param {string} deploymentId - Array of deploymentId.
+   * @return {*}  {Promise<Deployment>}
+   * @memberof DeploymentService
+   */
+  async getDeploymentById(deploymentId: string): Promise<Deployment> {
+    return this.repository.getDeploymentById(deploymentId);
+  }
+
+  /**
+   * Get deployment (aka: collar animal assignment) records by deployment_ids.
+   *
    * @param {string[]} deployment_ids - Array of deployment_ids.
    * @return {*}  {Promise<Deployment[]>}
    * @memberof DeploymentService
    */
   async getDeployments(deployment_ids: string[]): Promise<Deployment[]> {
     return this.repository.getDeployments(deployment_ids);
+  }
+
+  /**
+   * Create Deployments
+   *
+   * @param {ICreateDeployment} deployment
+   * @return {*}  {Promise<Deployment>}
+   * @memberof DeploymentService
+   */
+  async createDeployment(deployment: ICreateDeployment): Promise<Deployment> {
+    return this.repository.createDeployment(deployment);
+  }
+
+  /**
+   * Update Deployments
+   *
+   * @param {UpdateDeployment} deployment
+   * @return {*}  {Promise<Deployment>}
+   * @memberof DeploymentService
+   */
+  async updateDeployment(deployment: UpdateDeployment): Promise<Deployment> {
+    return this.repository.updateDeployment(deployment);
+  }
+
+  /**
+   * Delete Deployments
+   *
+   * @param {DeleteDeployment} deployment
+   * @return {*}  {Promise<Deployment>}
+   * @memberof DeploymentService
+   */
+  async deleteDeployment(deployment: DeleteDeployment): Promise<Deployment> {
+    return this.repository.deleteDeployment(deployment);
   }
 }

--- a/bctw-api/src/types/base_types.ts
+++ b/bctw-api/src/types/base_types.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 export interface BCTWBaseType {
   created_at?: Date;
   created_by_user_id?: number;
@@ -6,3 +8,12 @@ export interface BCTWBaseType {
   valid_from: Date;
   valid_to: Date;
 }
+
+export const BCTWBaseTypeSchema = z.object({
+  created_at: z.date().optional(),
+  created_by_user_id: z.number().optional(),
+  updated_at: z.date().optional(),
+  updated_by_user_id: z.number().optional(),
+  valid_from: z.date(),
+  valid_to: z.date(),
+});

--- a/bctw-api/src/types/collar.ts
+++ b/bctw-api/src/types/collar.ts
@@ -1,25 +1,28 @@
 import { z } from 'zod';
-import { BCTWBaseType } from './base_types';
+import { BCTWBaseTypeSchema } from './base_types';
 
-export interface ICollar extends BCTWBaseType {
-  camera_device_id: number;
-  collar_transaction_id: string;
-  device_deployment_status: string;
-  device_id: number;
-  device_make: string;
-  device_model: string;
-  device_type: string;
-  dropoff_device_id: number;
-  dropoff_frequency: number;
-  dropoff_frequency_unit: string;
-  fix_success_rate: number;
-  frequency_unit: string;
-  malfunction_date: Date;
-  malfunction_type: string;
-  retrieval_date: Date;
-  retrieved_ind: boolean;
-  satellite_network: string;
-}
+// Assuming BCTWBaseTypeSchema is already defined
+export const CollarSchema = BCTWBaseTypeSchema.extend({
+  camera_device_id: z.number(),
+  collar_transaction_id: z.string(),
+  device_deployment_status: z.string(),
+  device_id: z.number(),
+  device_make: z.string(),
+  device_model: z.string(),
+  device_type: z.string(),
+  dropoff_device_id: z.number(),
+  dropoff_frequency: z.number(),
+  dropoff_frequency_unit: z.string(),
+  fix_success_rate: z.number(),
+  frequency_unit: z.string(),
+  malfunction_date: z.date(),
+  malfunction_type: z.string(),
+  retrieval_date: z.date(),
+  retrieved_ind: z.boolean(),
+  satellite_network: z.string(),
+});
+
+export type ICollar = z.infer<typeof CollarSchema>;
 
 export class Collar implements ICollar {
   camera_device_id: number;
@@ -46,11 +49,26 @@ export class Collar implements ICollar {
   valid_to: Date;
 }
 
-export const UpdateCollarRequest = z.object({
+export const UpdateCollarSchema = z.object({
   collar_id: z.string().uuid(),
-  device_make: z.number().nullable().optional(),
+  device_id: z.number().nullable().optional(),
+  device_make: z.string().nullable().optional(),
   device_model: z.string().nullable().optional(),
   frequency: z.number().nullable().optional(),
-  frequency_unit: z.number().nullable().optional(),
+  frequency_unit: z.string().nullable().optional(),
 });
-export type UpdateCollarRequest = z.infer<typeof UpdateCollarRequest>;
+export type UpdateCollar = z.infer<typeof UpdateCollarSchema>;
+
+export const CreateCollarSchema = z.object({
+  device_id: z.number(),
+  device_make: z.string(),
+  device_model: z.string().nullable(),
+  frequency: z.number(),
+  frequency_unit: z.string(),
+});
+export type CreateCollar = z.infer<typeof CreateCollarSchema>;
+
+export const DeleteCollarSchema = z.object({
+  collar_id: z.string().uuid(),
+});
+export type DeleteCollar = z.infer<typeof DeleteCollarSchema>;

--- a/bctw-api/src/types/deployment.ts
+++ b/bctw-api/src/types/deployment.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ICollar } from './collar';
 
 // Schema for the collar animal assignment table record
 export const CollarAnimalAssignmentRecordSchema = z.object({
@@ -33,3 +34,47 @@ export type CollarAnimalAssignmentRecord = z.infer<
   typeof CollarAnimalAssignmentRecordSchema
 >;
 export type Deployment = z.infer<typeof DeploymentSchema>;
+
+export interface ICreateDeployment {
+  deployment_id: string;
+  collar_id: string;
+  critter_id: string;
+  attachment_start: Date;
+  attachment_end: Date;
+}
+
+export const CreateDeploymentSchema = z.object({
+  device_id: z.number(),
+  device_make: z.string(),
+  device_model: z.string(),
+  deployment_id: z.string(),
+  frequency: z.number(),
+  frequency_unit: z.string(),
+  critter_id: z.string(),
+  attachment_start: z.date(),
+  attachment_end: z.date(),
+});
+
+export type CreateDeployment = z.infer<typeof CreateDeploymentSchema>;
+
+export const CreateDeploymentArraySchema = z.array(CreateDeploymentSchema);
+
+export const UpdateDeploymentSchema = z.object({
+  deployment_id: z.string().uuid(),
+  device_id: z.number().nullable().optional(),
+  device_make: z.string().nullable().optional(),
+  device_model: z.string().nullable().optional(),
+  frequency: z.number().nullable().optional(),
+  frequency_unit: z.string().nullable().optional(),
+  critter_id: z.string().nullable().optional(),
+  attachment_start: z.date().nullable().optional(),
+  attachment_end: z.date().nullable().optional(),
+});
+
+export type UpdateDeployment = z.infer<typeof UpdateDeploymentSchema>;
+
+export const DeleteDeploymentSchema = z.object({
+  deployment_id: z.string().uuid(),
+});
+
+export type DeleteDeployment = z.infer<typeof DeleteDeploymentSchema>;


### PR DESCRIPTION
## Description of changes
* Adds create, update and delete operations for managing deployments in SIMS

*Notes*:
* Work in progress that intends to isolate and improve API components used by SIMS
* Probably need to switch from soft deletes to hard deletes for some of the repository functions to work (eg. ```getDeploymentById```)