### PR TITLE
BugFix: Change file path when verifying Cypress installation in data collector dockerfile

### DIFF
--- a/data-collector/Dockerfile
+++ b/data-collector/Dockerfile
@@ -10,10 +10,10 @@ RUN n stable
 RUN which node; node -v; which npm; npm -v; npm ls -g --depth=0
 
 COPY package*.json ./
-RUN npm install
+RUN npm ci
 
 # confirm cypress can run
-RUN $(npm bin)/cypress verify
+RUN ./node_modules/.bin/cypress verify
 
 # should be "root"
 RUN whoami


### PR DESCRIPTION
The Data Collector image is failing to build at ```RUN ${npm bin}/cypress```. 

* Recreated the error locally
* Replaced ```${npm bin}/cypress``` with ```./node_modules/.bin/cypress``` and the image successfully built